### PR TITLE
本番環境から赤外線信号送信できるように

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,10 +41,27 @@ http://localhost:3000/determinant
 
 ### 起動方法
 
-This is a [Next.js](https://nextjs.org/) project bootstrapped with [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app).
+0. This is a [Next.js](https://nextjs.org/) project bootstrapped with [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app).
+
+1. 環境変数を設定
+
+| 変数名 | 説明 |
+| ------------- | ------------- |
+| TOKEN | https://github.com/OpenWonderLabs/SwitchBotAPI#getting-started |
+| SECRET | https://github.com/OpenWonderLabs/SwitchBotAPI#getting-started |
+| DEVICE_ID | SwitchBot Hub 経由の仮想デバイスID |
+| ALARM_ENV | `development`, `production` |
+
+下記コマンドを実行するととりあえず動きます
 
 ```bash
-yarn dev
+touch .env.local && echo "TOKEN=tokentokentoken" > .env.local && echo "SECRET=secretsecret" >> .env.local && echo "DEVICE_ID=02-00000000" >> .env.local && echo "ALARM_ENV=development" >> .env.local
+```
+
+2. 開発サーバーを起動
+
+```bash
+yarn && yarn dev
 ```
 
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ http://localhost:3000/determinant
 下記コマンドを実行するととりあえず動きます
 
 ```bash
-touch .env.local && echo "TOKEN=tokentokentoken" > .env.local && echo "SECRET=secretsecret" >> .env.local && echo "DEVICE_ID=02-00000000" >> .env.local && echo "ALARM_ENV=development" >> .env.local
+echo "TOKEN=tokentokentoken" > .env.local && echo "SECRET=secretsecret" >> .env.local && echo "DEVICE_ID=02-00000000" >> .env.local && echo "ALARM_ENV=development" >> .env.local
 ```
 
 2. 開発サーバーを起動

--- a/types/env.d.ts
+++ b/types/env.d.ts
@@ -1,0 +1,12 @@
+declare module 'process' {
+  global {
+    namespace NodeJS {
+      interface ProcessEnv { 
+        TOKEN: string, 
+        SECRET: string, 
+        DEVICE_ID: string,
+        ALARM_ENV: 'production' | 'development'
+      }
+    }
+  }
+}


### PR DESCRIPTION
本番展開に伴いSwitchBot APIにリクエストを送れるように修正しました。
環境変数`ALARM_ENV`の値によって、本当に送るかモックを呼ぶか切り替えられます。

### `.env.local`が`ALARM_ENV=development`

```
Object { message: "mock" }          [index.tsx:11:4]
```

### `.env.local`が`ALARM_ENV=production`

```
Object { message: "success" }          [index.tsx:11:4]
```